### PR TITLE
Removed fog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,5 @@ gem 'rails_12factor', group: :production
 gem 'paperclip', '~> 4.2.0'
 gem 'aws-sdk', '~> 1.54.0'
 gem 'cancancan'
-gem 'fog'
 gem 'mail_form'
 gem 'simple_form'
-gem "simple_calendar", "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,6 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    excon (0.39.6)
     execjs (2.2.1)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -101,30 +100,6 @@ GEM
     fastercsv (1.5.5)
     figaro (1.0.0)
       thor (~> 0.14)
-    fog (1.23.0)
-      fog-brightbox
-      fog-core (~> 1.23)
-      fog-json
-      fog-softlayer
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.5.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto
-    fog-core (1.24.0)
-      builder
-      excon (~> 0.38)
-      formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-    fog-json (1.0.0)
-      multi_json (~> 1.0)
-    fog-softlayer (0.3.19)
-      fog-core
-      fog-json
-    formatador (0.2.5)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     globalid (0.3.5)
@@ -134,8 +109,6 @@ GEM
     highline (1.6.21)
     hike (1.2.3)
     i18n (0.7.0)
-    inflecto (0.0.2)
-    ipaddress (0.8.0)
     jbuilder (2.1.3)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -157,9 +130,6 @@ GEM
     mini_portile (0.6.0)
     minitest (5.7.0)
     multi_json (1.11.2)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     paperclip (4.2.0)
@@ -247,8 +217,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     sexp_processor (4.6.0)
-    simple_calendar (1.1.5)
-      rails (>= 3.0)
     simple_form (3.0.2)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -297,7 +265,6 @@ DEPENDENCIES
   factory_girl_rails (~> 4.4.1)
   faker
   figaro
-  fog
   friendly_id (~> 5.1.0)
   jbuilder (~> 2.0)
   jquery-rails
@@ -313,7 +280,6 @@ DEPENDENCIES
   rspec-rails (~> 3.1.0)
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
-  simple_calendar (~> 1.1.0)
   simple_form
   sprig (~> 0.1)
   spring

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,8 @@ class Item < ActiveRecord::Base
   belongs_to :restaurant
 
   has_attached_file :image, default_url: 'missing.png'
-  validates_attachment :image, content_type: {content_type: ["image/jpeg", "image/jpeg", "image/png", "image/gif"]}
+  validates_attachment :image, content_type: {content_type: ["image/jpeg", "image/jpeg", "image/png", "image/gif"]},
+    size: {in: 0..4.megabytes }
 
   scope :active, -> {where(active: true)}
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,14 +35,12 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.paperclip_defaults = {
-    :storage => :fog,
-    :fog_credentials => {
-      :provider => "AWS",
-      :aws_access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-      :aws_secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-    },
-    :fog_directory => ENV["S3_BUCKET_NAME"],
-    :default_url => "http://turingproject.s3.amazonaws.com/:style/missing.png"
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV['S3_BUCKET_NAME'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    }
   }
 
   ActionMailer::Base.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,22 +77,21 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.paperclip_defaults = {
-    :storage => :fog,
-    :fog_credentials => {
-      :provider => "AWS",
-      :aws_access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-      :aws_secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-    },
-    :fog_directory => ENV["S3_BUCKET_NAME"]
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV['S3_BUCKET_NAME'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    }
   }
 
   ActionMailer::Base.smtp_settings = {
-  :user_name => ENV['SG_USERNAME'],
-  :password => ENV['SG_PASSWORD'],
-  :domain => 'localhost:3000',
-  :address => 'smtp.sendgrid.net',
-  :port => 587,
-  :authentication => :plain,
-  :enable_starttls_auto => true
-}
-  end
+    :user_name => ENV['SG_USERNAME'],
+    :password => ENV['SG_PASSWORD'],
+    :domain => 'localhost:3000',
+    :address => 'smtp.sendgrid.net',
+    :port => 587,
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
+end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,3 @@
+Paperclip::Attachment.default_options[:url] = 's3_domain_url'
+Paperclip::Attachment.default_options[:path] = ':class/:attachment/:id_partition/:style/:filename'
+Paperclip::Attachment.default_options[:s3_host_name] = 's3-us-west-2.amazonaws.com'


### PR DESCRIPTION
- Storage for paperclip is now S3 directly as rcommended by
  heroku. I suppose fog is nice if you are looking to use
  mulitiple cloud storage solutions in the same app but since
  we are only using S3 it's much easier to config that directly.
